### PR TITLE
Close response body correctly and optimize base58 decode

### DIFF
--- a/neo/request.go
+++ b/neo/request.go
@@ -39,6 +39,7 @@ func executeRequest(method string, bodyParameters []interface{}, nodeURI string,
 	if err != nil {
 		return err
 	}
+	defer response.Body.Close()
 
 	if response.StatusCode > 200 {
 		return fmt.Errorf(
@@ -51,7 +52,6 @@ func executeRequest(method string, bodyParameters []interface{}, nodeURI string,
 	if err != nil {
 		return err
 	}
-	defer response.Body.Close()
 
 	err = json.Unmarshal(bytes, &model)
 	if err != nil {

--- a/neo/wif.go
+++ b/neo/wif.go
@@ -1,6 +1,7 @@
 package neo
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -61,10 +62,8 @@ func (w WIF) ToPrivateKey() (*PrivateKey, error) {
 	firstFourBytes := secondSHA[:4]
 	lastFourBytes := decoded[len(decoded)-4 : len(decoded)]
 
-	for i, x := range firstFourBytes {
-		if x != lastFourBytes[i] {
-			return nil, fmt.Errorf("WIF failed checksum validation")
-		}
+	if !bytes.Equal(firstFourBytes, lastFourBytes) {
+		return nil, fmt.Errorf("WIF failed checksum validation")
 	}
 
 	privateKey := NewPrivateKey(

--- a/neo/wif_test.go
+++ b/neo/wif_test.go
@@ -7,6 +7,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func BenchmarkWIF(b *testing.B) {
+	in := "L1QqQJnpBwbsPGAuutuzPTac8piqvbR1HRjrY5qHup48TBCBFe4g"
+
+	for i := 0; i < b.N; i++ {
+		wif := neo.NewWIF(in)
+		wif.ToPrivateKey()
+	}
+}
+
 func TestWIF(t *testing.T) {
 	t.Run(".ToPrivateKey()", func(t *testing.T) {
 		t.Run("HappyCase", func(t *testing.T) {

--- a/utility/base_58.go
+++ b/utility/base_58.go
@@ -1,7 +1,6 @@
 package utility
 
 import (
-	"bytes"
 	"fmt"
 	"math/big"
 )
@@ -9,40 +8,41 @@ import (
 type (
 	// Base58 is a encode/decode utility for base58 strings.
 	Base58 struct {
-		alphabet  [58]byte
-		decodeMap map[byte]int64
+		decodeMap map[rune]int64
 	}
 )
 
-const (
-	defaultAlphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
-)
+const prefix rune = '1'
+
+var decodeMap = map[rune]int64{
+	'1': 0, '2': 1, '3': 2, '4': 3, '5': 4,
+	'6': 5, '7': 6, '8': 7, '9': 8, 'A': 9,
+	'B': 10, 'C': 11, 'D': 12, 'E': 13, 'F': 14,
+	'G': 15, 'H': 16, 'J': 17, 'K': 18, 'L': 19,
+	'M': 20, 'N': 21, 'P': 22, 'Q': 23, 'R': 24,
+	'S': 25, 'T': 26, 'U': 27, 'V': 28, 'W': 29,
+	'X': 30, 'Y': 31, 'Z': 32, 'a': 33, 'b': 34,
+	'c': 35, 'd': 36, 'e': 37, 'f': 38, 'g': 39,
+	'h': 40, 'i': 41, 'j': 42, 'k': 43, 'm': 44,
+	'n': 45, 'o': 46, 'p': 47, 'q': 48, 'r': 49,
+	's': 50, 't': 51, 'u': 52, 'v': 53, 'w': 54,
+	'x': 55, 'y': 56, 'z': 57,
+}
 
 // NewBase58 creates a new Base58 struct, using the default alphabet.
 func NewBase58() Base58 {
 	base58 := Base58{}
-
-	copy(base58.alphabet[:], []byte(defaultAlphabet))
-
-	base58.decodeMap = map[byte]int64{}
-	for i, b := range []byte(defaultAlphabet) {
-		base58.decodeMap[b] = int64(i)
-	}
-
 	return base58
 }
 
 // Decode decodes the base58 encoded string.
 func (b Base58) Decode(s string) ([]byte, error) {
-	source := []byte(s)
 	startIndex := 0
-	buffer := &bytes.Buffer{}
+	zero := 0
 
-	for i, c := range source {
-		if c == b.alphabet[0] {
-			if err := buffer.WriteByte(0x00); err != nil {
-				return nil, err
-			}
+	for i, c := range s {
+		if c == prefix {
+			zero++
 		} else {
 			startIndex = i
 			break
@@ -52,18 +52,20 @@ func (b Base58) Decode(s string) ([]byte, error) {
 	n := big.NewInt(0)
 	div := big.NewInt(58)
 
-	for _, c := range source[startIndex:] {
-		charIndex, ok := b.decodeMap[c]
+	for _, c := range s[startIndex:] {
+		charIndex, ok := decodeMap[c]
 		if !ok {
 			return nil, fmt.Errorf(
-				"invalid character '%c' when decoding this base58 string: '%s'", c, source,
+				"invalid character '%c' when decoding this base58 string: '%s'", c, s,
 			)
 		}
 
 		n.Add(n.Mul(n, div), big.NewInt(charIndex))
 	}
 
-	buffer.Write(n.Bytes())
+	out := n.Bytes()
+	buf := make([]byte, (zero + len(out)))
+	copy(buf[zero:], out[:])
 
-	return buffer.Bytes(), nil
+	return buf, nil
 }

--- a/utility/base_58_test.go
+++ b/utility/base_58_test.go
@@ -8,6 +8,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func BenchmarkBase58(b *testing.B) {
+	in := "16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM"
+	for i := 0; i < b.N; i++ {
+		base58 := utility.NewBase58()
+		base58.Decode(in)
+	}
+}
+
 func TestBase58(t *testing.T) {
 	t.Run(".Decode()", func(t *testing.T) {
 		t.Run("HappyCase", func(t *testing.T) {


### PR DESCRIPTION
### Problem

1. Request body was not being closed properly for non-200 responses.
2. Unneeded map usage and allocations in `base58` package.
3. `client.Ping` does not close tcp connections (no fix) -- should be addressed. Will cause too many open files and possible memory leak.

### Solution

1. Move `defer response.Body.Close()` before status code. Better tests should be added, but this fixes a memory leak.
2. Couple of changes here:
- convert `defaultAlphabet` to a hash table -- safe to be read concurrently, no need to copy map for each key.
- use only slice of bytes instead of `bytes.Buffer` for return payload
3. No change. A solution should be planned

Before:
```
go test -bench=. -benchmem -cpu 1,2,4
BenchmarkBase58           100000             20614 ns/op            6128 B/op         86 allocs/op
BenchmarkBase58-2         100000             19076 ns/op            6128 B/op         86 allocs/op
BenchmarkBase58-4         100000             19707 ns/op            6127 B/op         86 allocs/op
```

After:
```
go test -bench=. -benchmem -cpu 1,2,4
BenchmarkBase58           200000              7300 ns/op            2784 B/op         70 allocs/op
BenchmarkBase58-2         200000              6725 ns/op            2784 B/op         70 allocs/op
BenchmarkBase58-4         200000              6834 ns/op            2784 B/op         70 allocs/op
```

### Remember

- Bump `VERSION`
- Update `CHANGELOG.md`
- Update `README.md`
- Write tests